### PR TITLE
Enable configuration of CFN stack wait_until configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ Style/FrozenStringLiteralComment:
   Enabled: false
 
 Metrics/MethodLength:
-  Max: 15
+  Max: 25
 
 Metrics/AbcSize:
   Enabled: false

--- a/spec/cloudformation_spec.rb
+++ b/spec/cloudformation_spec.rb
@@ -102,10 +102,15 @@ describe MinimalPipeline::Cloudformation do
         foo: 'bar'
       }
 
+      wait_options = {
+        delay: 30,
+        max_attempts: 120
+      }
+
       client = double(Aws::CloudFormation::Client)
 
       expect(client).to receive(:describe_stacks).and_raise(Aws::CloudFormation::Errors::ValidationError.new('foo', 'bar'))
-      expect(client).to receive(:wait_until).with(:stack_create_complete, stack_name: 'STACK-NAME').and_return(true)
+      expect(client).to receive(:wait_until).with(:stack_create_complete, { stack_name: 'STACK-NAME' }, wait_options).and_return(true)
       expect(client).to receive(:create_stack).with(stack_parameters)
       expect(Aws::CloudFormation::Client).to receive(:new).with(region: 'us-east-1').and_return(client)
 
@@ -116,6 +121,11 @@ describe MinimalPipeline::Cloudformation do
     it 'updates a new stack if it already exists' do
       stack_parameters = {
         foo: 'bar'
+      }
+
+      wait_options = {
+        delay: 30,
+        max_attempts: 120
       }
 
       outputs = [
@@ -136,7 +146,7 @@ describe MinimalPipeline::Cloudformation do
 
       expect(client).to receive(:describe_stacks).with(stack_name: 'STACK-NAME').and_return(response)
       expect(response).to receive(:stacks).and_return(stacks).at_least(:once)
-      expect(client).to receive(:wait_until).with(:stack_update_complete, stack_name: 'STACK-NAME').and_return(true)
+      expect(client).to receive(:wait_until).with(:stack_update_complete, { stack_name: 'STACK-NAME' }, wait_options).and_return(true)
       expect(client).to receive(:update_stack).with(stack_parameters)
 
       expect(Aws::CloudFormation::Client).to receive(:new).with(region: 'us-east-1').and_return(client)


### PR DESCRIPTION
The AWS accounts are starting to face this error:

`Aws::Waiters::Errors::UnexpectedError: stopped waiting due to an unexpected error: Rate exceeded`

This indicates we are beginning to hit rate limits. This code will
allow end uses to customize the default delay and max attempts to
hopefully alleviate rate limits.

Default values are from the SDK code:

https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-cloudformation/lib/aws-sdk-cloudformation/waiters.rb#L25-L26