### PR TITLE
Refactoring CFN stack operations to be more DRY

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ Style/FrozenStringLiteralComment:
   Enabled: false
 
 Metrics/MethodLength:
-  Max: 25
+  Max: 30
 
 Metrics/AbcSize:
   Enabled: false

--- a/lib/minimal_pipeline/cloudformation.rb
+++ b/lib/minimal_pipeline/cloudformation.rb
@@ -8,21 +8,14 @@ class MinimalPipeline
   # ```
   # cloudformation = MinimalPipeline::Cloudformation.new
   #
-  # cloudformation_parameters = {
+  # parameters = {
   #   'Vpc' => 'vpc-123456',
   #   'AsgSubnets' => %w[sg-one sg-two sg-three],
   #   'ElbSecurityGroup' => 'sg-123456',
   #   'CertName' => 'example'
   # }
   #
-  # stack_parameters = {
-  #   stack_name: stack_name,
-  #   template_body: File.read('provisioning/elb.json'),
-  #   capabilities: ['CAPABILITY_IAM'],
-  #   parameters: cloudformation.params(cloudformation_parameters)
-  # }
-  #
-  # cloudformation.deploy_stack('EXAMPLE_ELB', stack_parameters)
+  # cloudformation.deploy_stack('EXAMPLE_ELB', parameters, 'stack.yaml')
   # name = cloudformation.stack_output(stack_name, 'LoadBalancerName')
   # ```
   #
@@ -101,10 +94,18 @@ class MinimalPipeline
 
     # @param stack_name [String] The name of the CloudFormation stack
     # @param stack_parameters [Hash] Parameters to be passed into the stack
-    def deploy_stack(stack_name, stack_parameters)
+    def deploy_stack(stack_name, parameters, template,
+                     capabilities = ['CAPABILITY_IAM'])
       wait_options = {
         max_attempts: @wait_max_attempts,
         delay: @wait_delay
+      }
+
+      stack_parameters = {
+        stack_name: stack_name,
+        template_body: File.read(template),
+        capabilities: capabilities,
+        parameters: params(parameters)
       }
 
       unless @client.describe_stacks(stack_name: stack_name).stacks.empty?

--- a/minimal_pipeline.gemspec
+++ b/minimal_pipeline.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Mayowa Aladeojebi', 'Jesse Adams']
   spec.email         = ['mayowa.aladeojebi@stelligent.com',
                         'jesse.adams@stelligent.com']
-  spec.version       = '0.0.21'
+  spec.version       = '0.1.0'
   spec.summary       = 'Helper gem to manage pipeline tasks'
   spec.description   = 'Helper gem to orchestrate pipeline tasks'
   spec.homepage      = 'https://github.com/stelligent/minimal-pipeline-gem'


### PR DESCRIPTION
Turns:

```ruby
cloudformation = MinimalPipeline::Cloudformation.new

cloudformation_parameters = {
  'Vpc' => 'vpc-123456',
  'AsgSubnets' => %w[sg-one sg-two sg-three],
  'ElbSecurityGroup' => 'sg-123456',
  'CertName' => 'example'
}

stack_parameters = {
  stack_name: stack_name,
  template_body: File.read('provisioning/elb.json'),
  capabilities: ['CAPABILITY_IAM'],
  parameters: cloudformation.params(cloudformation_parameters)
}

cloudformation.deploy_stack('EXAMPLE_ELB', stack_parameters)
name = cloudformation.stack_output(stack_name, 'LoadBalancerName')
```

Into

```ruby
cloudformation = MinimalPipeline::Cloudformation.new

cloudformation_parameters = {
  'Vpc' => 'vpc-123456',
  'AsgSubnets' => %w[sg-one sg-two sg-three],
  'ElbSecurityGroup' => 'sg-123456',
  'CertName' => 'example'
}

cloudformation.deploy_stack('EXAMPLE_ELB', parameters, 'provisioning/elb.json')
name = cloudformation.stack_output(stack_name, 'LoadBalancerName')
```